### PR TITLE
NoError Cancel Functions

### DIFF
--- a/dex/src/instruction.rs
+++ b/dex/src/instruction.rs
@@ -320,6 +320,23 @@ impl CancelOrderInstructionV2 {
 #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(test, derive(Arbitrary))]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+pub struct CancelOrderNoErrorInstructionV2 {
+    pub side: Side,
+    pub order_id: u128,
+}
+
+impl CancelOrderNoErrorInstructionV2 {
+    fn unpack(data: &[u8; 20]) -> Option<Self> {
+        let (&side_arr, &oid_arr) = array_refs![data, 4, 16];
+        let side = Side::try_from_primitive(u32::from_le_bytes(side_arr).try_into().ok()?).ok()?;
+        let order_id = u128::from_le_bytes(oid_arr);
+        Some(CancelOrderNoErrorInstructionV2 { side, order_id })
+    }
+}
+
+#[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(test, derive(Arbitrary))]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum MarketInstruction {
     /// 0. `[writable]` the market to initialize
     /// 1. `[writable]` zeroed out request queue
@@ -423,6 +440,13 @@ pub enum MarketInstruction {
     /// 4. `[signer]` the OpenOrders owner
     /// 5. `[writable]` event_q
     CancelOrderV2(CancelOrderInstructionV2),
+    /// 0. `[writable]` market
+    /// 1. `[writable]` bids
+    /// 2. `[writable]` asks
+    /// 3. `[writable]` OpenOrders
+    /// 4. `[signer]` the OpenOrders owner
+    /// 5. `[writable]` event_q
+    CancelOrderNoErrorV2(CancelOrderNoErrorInstructionV2),
     /// 0. `[writable]` market
     /// 1. `[writable]` bids
     /// 2. `[writable]` asks
@@ -545,21 +569,25 @@ impl MarketInstruction {
                 let data_arr = array_ref![data, 0, 20];
                 CancelOrderInstructionV2::unpack(data_arr)?
             }),
-            (12, 8) => {
+            (12, 20) => MarketInstruction::CancelOrderNoErrorV2({
+                let data_arr = array_ref![data, 0, 20];
+                CancelOrderNoErrorInstructionV2::unpack(data_arr)?
+            }),
+            (13, 8) => {
                 let client_id = array_ref![data, 0, 8];
                 MarketInstruction::CancelOrderByClientIdV2(u64::from_le_bytes(*client_id))
             }
-            (13, 46) => MarketInstruction::SendTake({
+            (14, 46) => MarketInstruction::SendTake({
                 let data_arr = array_ref![data, 0, 46];
                 SendTakeInstruction::unpack(data_arr)?
             }),
-            (14, 0) => MarketInstruction::CloseOpenOrders,
-            (15, 0) => MarketInstruction::InitOpenOrders,
-            (16, 2) => {
+            (15, 0) => MarketInstruction::CloseOpenOrders,
+            (16, 0) => MarketInstruction::InitOpenOrders,
+            (17, 2) => {
                 let limit = array_ref![data, 0, 2];
                 MarketInstruction::Prune(u16::from_le_bytes(*limit))
             }
-            (17, 2) => {
+            (18, 2) => {
                 let limit = array_ref![data, 0, 2];
                 MarketInstruction::ConsumeEventsPermissioned(u16::from_le_bytes(*limit))
             }
@@ -807,6 +835,35 @@ pub fn cancel_order(
     order_id: u128,
 ) -> Result<Instruction, DexError> {
     let data = MarketInstruction::CancelOrderV2(CancelOrderInstructionV2 { side, order_id }).pack();
+    let accounts: Vec<AccountMeta> = vec![
+        AccountMeta::new(*market, false),
+        AccountMeta::new(*market_bids, false),
+        AccountMeta::new(*market_asks, false),
+        AccountMeta::new(*open_orders_account, false),
+        AccountMeta::new_readonly(*open_orders_account_owner, true),
+        AccountMeta::new(*event_queue, false),
+    ];
+    Ok(Instruction {
+        program_id: *program_id,
+        data,
+        accounts,
+    })
+}
+
+pub fn cancel_order_no_error(
+    program_id: &Pubkey,
+    market: &Pubkey,
+    market_bids: &Pubkey,
+    market_asks: &Pubkey,
+    open_orders_account: &Pubkey,
+    open_orders_account_owner: &Pubkey,
+    event_queue: &Pubkey,
+    side: Side,
+    order_id: u128,
+) -> Result<Instruction, DexError> {
+    let data =
+        MarketInstruction::CancelOrderNoErrorV2(CancelOrderNoErrorInstructionV2 { side, order_id })
+            .pack();
     let accounts: Vec<AccountMeta> = vec![
         AccountMeta::new(*market, false),
         AccountMeta::new(*market_bids, false),

--- a/dex/src/matching.rs
+++ b/dex/src/matching.rs
@@ -930,6 +930,32 @@ impl<'ob> OrderBookState<'ob> {
         Ok(None)
     }
 
+    pub(crate) fn cancel_order_no_error_v2(
+        &mut self,
+        side: Side,
+        open_orders_address: [u64; 4],
+        open_orders: &mut OpenOrders,
+        order_id: u128,
+        event_q: &mut EventQueue,
+    ) -> DexResult {
+        let leaf_node = self
+            .orders_mut(side)
+            .remove_by_key(order_id)
+            .ok_or(DexErrorCode::OrderNotFound);
+
+        return match leaf_node {
+            Ok(leaf_node) => self.cancel_leaf_node(
+                leaf_node,
+                side,
+                open_orders,
+                open_orders_address,
+                order_id,
+                event_q,
+            ),
+            Err(_e) => Ok(()), // Silently drop the error on purpose and don't run cancel_leaf_node
+        };
+    }
+
     pub(crate) fn cancel_order_v2(
         &mut self,
         side: Side,

--- a/dex/src/matching.rs
+++ b/dex/src/matching.rs
@@ -930,6 +930,28 @@ impl<'ob> OrderBookState<'ob> {
         Ok(None)
     }
 
+    pub(crate) fn cancel_order_v2(
+        &mut self,
+        side: Side,
+        open_orders_address: [u64; 4],
+        open_orders: &mut OpenOrders,
+        order_id: u128,
+        event_q: &mut EventQueue,
+    ) -> DexResult {
+        let leaf_node = self
+            .orders_mut(side)
+            .remove_by_key(order_id)
+            .ok_or(DexErrorCode::OrderNotFound)?;
+        self.cancel_leaf_node(
+            leaf_node,
+            side,
+            open_orders,
+            open_orders_address,
+            order_id,
+            event_q,
+        )
+    }
+
     pub(crate) fn cancel_order_no_error_v2(
         &mut self,
         side: Side,
@@ -954,28 +976,6 @@ impl<'ob> OrderBookState<'ob> {
             ),
             Err(_e) => Ok(()), // Silently drop the error on purpose and don't run cancel_leaf_node
         };
-    }
-
-    pub(crate) fn cancel_order_v2(
-        &mut self,
-        side: Side,
-        open_orders_address: [u64; 4],
-        open_orders: &mut OpenOrders,
-        order_id: u128,
-        event_q: &mut EventQueue,
-    ) -> DexResult {
-        let leaf_node = self
-            .orders_mut(side)
-            .remove_by_key(order_id)
-            .ok_or(DexErrorCode::OrderNotFound)?;
-        self.cancel_leaf_node(
-            leaf_node,
-            side,
-            open_orders,
-            open_orders_address,
-            order_id,
-            event_q,
-        )
     }
 
     pub(crate) fn cancel_leaf_node(

--- a/dex/src/state.rs
+++ b/dex/src/state.rs
@@ -27,7 +27,7 @@ use crate::{
     fees::{self, FeeTier},
     instruction::{
         disable_authority, fee_sweeper, msrm_token, srm_token, CancelOrderInstructionV2,
-        CancelOrderNoErrorInstructionV2, InitializeMarketInstruction, MarketInstruction,
+        CancelOrderInstructionV2NoError, InitializeMarketInstruction, MarketInstruction,
         NewOrderInstructionV3, SelfTradeBehavior, SendTakeInstruction,
     },
     matching::{OrderBookState, OrderType, RequestProceeds, Side},
@@ -2013,20 +2013,20 @@ pub(crate) mod account_parser {
         }
     }
 
-    pub struct CancelOrderNoErrorV2Args<'a, 'b: 'a> {
-        pub instruction: &'a CancelOrderNoErrorInstructionV2,
+    pub struct CancelOrderV2NoErrorArgs<'a, 'b: 'a> {
+        pub instruction: &'a CancelOrderInstructionV2NoError,
         pub open_orders_address: [u64; 4],
         pub open_orders: &'a mut OpenOrders,
         pub open_orders_signer: SignerAccount<'a, 'b>,
         pub order_book_state: OrderBookState<'a>,
         pub event_q: EventQueue<'a>,
     }
-    impl<'a, 'b: 'a> CancelOrderNoErrorV2Args<'a, 'b> {
+    impl<'a, 'b: 'a> CancelOrderV2NoErrorArgs<'a, 'b> {
         pub fn with_parsed_args<T>(
             program_id: &'a Pubkey,
             accounts: &'a [AccountInfo<'b>],
-            instruction: &'a CancelOrderNoErrorInstructionV2,
-            f: impl FnOnce(CancelOrderNoErrorV2Args) -> DexResult<T>,
+            instruction: &'a CancelOrderInstructionV2NoError,
+            f: impl FnOnce(CancelOrderV2NoErrorArgs) -> DexResult<T>,
         ) -> DexResult<T> {
             check_assert!(accounts.len() >= 6)?;
             #[rustfmt::skip]
@@ -2062,7 +2062,7 @@ pub(crate) mod account_parser {
                 market_state: market.deref_mut(),
             };
 
-            let args = CancelOrderNoErrorV2Args {
+            let args = CancelOrderV2NoErrorArgs {
                 instruction,
                 open_orders_address,
                 open_orders: open_orders.deref_mut(),
@@ -2137,7 +2137,7 @@ pub(crate) mod account_parser {
         }
     }
 
-    pub struct CancelOrderByClientIdNoErrorV2Args<'a, 'b: 'a> {
+    pub struct CancelOrderByClientIdV2NoErrorArgs<'a, 'b: 'a> {
         pub client_order_id: NonZeroU64,
         pub open_orders_address: [u64; 4],
         pub open_orders: &'a mut OpenOrders,
@@ -2145,12 +2145,12 @@ pub(crate) mod account_parser {
         pub order_book_state: OrderBookState<'a>,
         pub event_q: EventQueue<'a>,
     }
-    impl<'a, 'b: 'a> CancelOrderByClientIdNoErrorV2Args<'a, 'b> {
+    impl<'a, 'b: 'a> CancelOrderByClientIdV2NoErrorArgs<'a, 'b> {
         pub fn with_parsed_args<T>(
             program_id: &'a Pubkey,
             accounts: &'a [AccountInfo<'b>],
             client_order_id: u64,
-            f: impl FnOnce(CancelOrderByClientIdNoErrorV2Args) -> DexResult<T>,
+            f: impl FnOnce(CancelOrderByClientIdV2NoErrorArgs) -> DexResult<T>,
         ) -> DexResult<T> {
             check_assert!(accounts.len() >= 6)?;
             #[rustfmt::skip]
@@ -2188,7 +2188,7 @@ pub(crate) mod account_parser {
                 market_state: market.deref_mut(),
             };
 
-            let args = CancelOrderByClientIdNoErrorV2Args {
+            let args = CancelOrderByClientIdV2NoErrorArgs {
                 client_order_id,
                 open_orders_address,
                 open_orders: open_orders.deref_mut(),
@@ -2573,8 +2573,8 @@ impl State {
                     Self::process_cancel_order_v2,
                 )?
             }
-            MarketInstruction::CancelOrderNoErrorV2(ref inner) => {
-                account_parser::CancelOrderNoErrorV2Args::with_parsed_args(
+            MarketInstruction::CancelOrderV2NoError(ref inner) => {
+                account_parser::CancelOrderV2NoErrorArgs::with_parsed_args(
                     program_id,
                     accounts,
                     inner,
@@ -2597,8 +2597,8 @@ impl State {
                     Self::process_cancel_order_by_client_id_v2,
                 )?
             }
-            MarketInstruction::CancelOrderByClientIdNoErrorV2(client_id) => {
-                account_parser::CancelOrderByClientIdNoErrorV2Args::with_parsed_args(
+            MarketInstruction::CancelOrderByClientIdV2NoError(client_id) => {
+                account_parser::CancelOrderByClientIdV2NoErrorArgs::with_parsed_args(
                     program_id,
                     accounts,
                     client_id,
@@ -2857,9 +2857,9 @@ impl State {
     }
 
     fn process_cancel_order_by_client_id_no_error_v2(
-        args: account_parser::CancelOrderByClientIdNoErrorV2Args,
+        args: account_parser::CancelOrderByClientIdV2NoErrorArgs,
     ) -> DexResult {
-        let account_parser::CancelOrderByClientIdNoErrorV2Args {
+        let account_parser::CancelOrderByClientIdV2NoErrorArgs {
             client_order_id,
             open_orders_address,
             open_orders,
@@ -2883,10 +2883,10 @@ impl State {
     }
 
     fn process_cancel_order_no_error_v2(
-        args: account_parser::CancelOrderNoErrorV2Args,
+        args: account_parser::CancelOrderV2NoErrorArgs,
     ) -> DexResult {
-        let account_parser::CancelOrderNoErrorV2Args {
-            instruction: &CancelOrderNoErrorInstructionV2 { side, order_id },
+        let account_parser::CancelOrderV2NoErrorArgs {
+            instruction: &CancelOrderInstructionV2NoError { side, order_id },
 
             open_orders_address,
             open_orders,


### PR DESCRIPTION
We add new "NoError" Cancel instructions to facilitate fancier things in the SDK. These instructions drop all errors, so that we can bundle multiple without failing if one fails.

Zeta DEX PR: https://github.com/zetamarkets/zeta-options/pull/427
SDK PR: https://github.com/zetamarkets/sdk/pull/114