### PR TITLE
PlaceOrderV3NoRent

### DIFF
--- a/dex/src/error.rs
+++ b/dex/src/error.rs
@@ -111,6 +111,7 @@ pub enum DexErrorCode {
 
     WouldSelfTrade,
     InvalidOpenOrdersAuthority,
+    OpenOrdersNotInitialized,
 
     Unknown = 1000,
 

--- a/dex/src/instruction.rs
+++ b/dex/src/instruction.rs
@@ -504,7 +504,7 @@ pub enum MarketInstruction {
     /// 8. `[writable]` coin vault
     /// 9. `[writable]` pc vault
     /// 10. `[]` spl token program
-    NewOrderV4(NewOrderInstructionV3),
+    NewOrderV3NoRent(NewOrderInstructionV3),
 }
 
 impl MarketInstruction {
@@ -616,7 +616,7 @@ impl MarketInstruction {
                 let client_id = array_ref![data, 0, 8];
                 MarketInstruction::CancelOrderByClientIdV2NoError(u64::from_le_bytes(*client_id))
             }
-            (20, 46) => MarketInstruction::NewOrderV3({
+            (20, 46) => MarketInstruction::NewOrderV3NoRent({
                 let data_arr = array_ref![data, 0, 46];
                 NewOrderInstructionV3::unpack(data_arr)?
             }),
@@ -794,7 +794,7 @@ pub fn new_order_v4(
     limit: u16,
     max_native_pc_qty_including_fees: NonZeroU64,
 ) -> Result<Instruction, DexError> {
-    let data = MarketInstruction::NewOrderV4(NewOrderInstructionV3 {
+    let data = MarketInstruction::NewOrderV3NoRent(NewOrderInstructionV3 {
         side,
         limit_price,
         max_coin_qty,

--- a/dex/src/instruction.rs
+++ b/dex/src/instruction.rs
@@ -772,7 +772,7 @@ pub fn new_order(
     })
 }
 
-pub fn new_order_v4(
+pub fn new_order_no_rent(
     market: &Pubkey,
     open_orders_account: &Pubkey,
     request_queue: &Pubkey,

--- a/dex/src/state.rs
+++ b/dex/src/state.rs
@@ -145,13 +145,11 @@ impl<'a> Market<'a> {
         orders_account: &'a AccountInfo,
         owner_account: Option<&AccountInfo>,
         program_id: &Pubkey,
-        open_orders_authority: Option<account_parser::SignerAccount>,
+        _open_orders_authority: Option<account_parser::SignerAccount>,
     ) -> DexResult<RefMut<'a, OpenOrders>> {
         check_assert_eq!(orders_account.owner, program_id)?;
-        let mut open_orders: RefMut<'a, OpenOrders>;
+        let open_orders: RefMut<'a, OpenOrders>;
 
-        let open_orders_data_len = orders_account.data_len();
-        let open_orders_lamports = orders_account.lamports();
         let (_, data) = strip_header::<[u8; 0], u8>(orders_account, true)?;
         open_orders = RefMut::map(data, |data| from_bytes_mut(data));
 
@@ -2675,7 +2673,7 @@ impl State {
                     Self::process_new_order_v3,
                 )?
             }
-            MarketInstruction::NewOrderV4(ref inner) => {
+            MarketInstruction::NewOrderV3NoRent(ref inner) => {
                 account_parser::NewOrderV3Args::with_parsed_args_no_rent(
                     program_id,
                     inner,


### PR DESCRIPTION
There isn't rent required in this instruction, meaning place order from dex has 1 less account to use.