### PR TITLE
Self trade behavior

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os: linux
 env:
   global:
     - NODE_VERSION="v14.7.0"
-    - SOLANA_VERSION="v1.6.18"
+    - SOLANA_VERSION="v1.14.16"
 
 _defaults: &defaults
   cache: false

--- a/dex/src/matching.rs
+++ b/dex/src/matching.rs
@@ -790,18 +790,15 @@ impl<'ob> OrderBookState<'ob> {
 
                 let cancelled_take_qty;
                 let cancelled_provide_qty;
-                let mut release = true;
 
                 match self_trade_behavior {
                     SelfTradeBehavior::CancelProvide => {
                         cancelled_take_qty = 0;
                         cancelled_provide_qty = offer_size;
-                        release = false;
                     }
                     SelfTradeBehavior::DecrementTake => {
                         cancelled_take_qty = trade_qty;
                         cancelled_provide_qty = trade_qty;
-                        release = false;
                     }
                     SelfTradeBehavior::AbortTransaction => {
                         return Err(DexErrorCode::WouldSelfTrade.into())
@@ -811,7 +808,7 @@ impl<'ob> OrderBookState<'ob> {
                 let remaining_provide_qty = offer_size - cancelled_provide_qty;
                 let provide_out = Event::new(EventView::Out {
                     side: Side::Ask,
-                    release_funds: release,
+                    release_funds: false,
                     native_qty_unlocked: cancelled_provide_qty * coin_lot_size,
                     native_qty_still_locked: remaining_provide_qty * coin_lot_size,
                     order_id: best_offer_id,

--- a/dex/src/matching.rs
+++ b/dex/src/matching.rs
@@ -812,7 +812,7 @@ impl<'ob> OrderBookState<'ob> {
                 let remaining_provide_qty = offer_size - cancelled_provide_qty;
                 let provide_out = Event::new(EventView::Out {
                     side: Side::Ask,
-                    release_funds: false,
+                    release_funds: true,
                     native_qty_unlocked: cancelled_provide_qty * coin_lot_size,
                     native_qty_still_locked: remaining_provide_qty * coin_lot_size,
                     order_id: best_offer_id,

--- a/dex/src/matching.rs
+++ b/dex/src/matching.rs
@@ -790,15 +790,18 @@ impl<'ob> OrderBookState<'ob> {
 
                 let cancelled_take_qty;
                 let cancelled_provide_qty;
+                let mut release = true;
 
                 match self_trade_behavior {
                     SelfTradeBehavior::CancelProvide => {
                         cancelled_take_qty = 0;
                         cancelled_provide_qty = offer_size;
+                        release = false;
                     }
                     SelfTradeBehavior::DecrementTake => {
                         cancelled_take_qty = trade_qty;
                         cancelled_provide_qty = trade_qty;
+                        release = false;
                     }
                     SelfTradeBehavior::AbortTransaction => {
                         return Err(DexErrorCode::WouldSelfTrade.into())
@@ -808,7 +811,7 @@ impl<'ob> OrderBookState<'ob> {
                 let remaining_provide_qty = offer_size - cancelled_provide_qty;
                 let provide_out = Event::new(EventView::Out {
                     side: Side::Ask,
-                    release_funds: true,
+                    release_funds: release,
                     native_qty_unlocked: cancelled_provide_qty * coin_lot_size,
                     native_qty_still_locked: remaining_provide_qty * coin_lot_size,
                     order_id: best_offer_id,

--- a/dex/src/matching.rs
+++ b/dex/src/matching.rs
@@ -458,15 +458,17 @@ impl<'ob> OrderBookState<'ob> {
                 let best_bid_id = order_id;
                 let cancelled_provide_qty;
                 let cancelled_take_qty;
-
+                let mut release = true;
                 match self_trade_behavior {
                     SelfTradeBehavior::DecrementTake => {
                         cancelled_provide_qty = trade_qty;
                         cancelled_take_qty = trade_qty;
+                        release = false;
                     }
                     SelfTradeBehavior::CancelProvide => {
                         cancelled_provide_qty = best_bid_ref.quantity();
                         cancelled_take_qty = 0;
+                        release = false;
                     }
                     SelfTradeBehavior::AbortTransaction => {
                         return Err(DexErrorCode::WouldSelfTrade.into())
@@ -476,7 +478,7 @@ impl<'ob> OrderBookState<'ob> {
                 let remaining_provide_size = bid_size - cancelled_provide_qty;
                 let provide_out = Event::new(EventView::Out {
                     side: Side::Bid,
-                    release_funds: true,
+                    release_funds: release,
                     native_qty_unlocked: cancelled_provide_qty * trade_price.get() * pc_lot_size,
                     native_qty_still_locked: remaining_provide_size
                         * trade_price.get()

--- a/dex/src/state.rs
+++ b/dex/src/state.rs
@@ -1244,7 +1244,6 @@ enum EventFlag {
     Bid = 0x4,
     Maker = 0x8,
     ReleaseFunds = 0x10,
-    SelfTradeCancel = 0x20,
 }
 
 impl EventFlag {
@@ -1401,8 +1400,7 @@ impl Event {
         check_assert!(allowed_flags.contains(flags))?;
         Ok(EventView::Out {
             side,
-            release_funds: flags.contains(EventFlag::ReleaseFunds)
-                && flags.contains(EventFlag::SelfTradeCancel),
+            release_funds: flags.contains(EventFlag::ReleaseFunds),
             native_qty_unlocked: self.native_qty_released,
             native_qty_still_locked: self.native_qty_paid,
 

--- a/dex/src/state.rs
+++ b/dex/src/state.rs
@@ -1244,6 +1244,7 @@ enum EventFlag {
     Bid = 0x4,
     Maker = 0x8,
     ReleaseFunds = 0x10,
+    SelfTradeCancel = 0x20,
 }
 
 impl EventFlag {
@@ -1400,7 +1401,8 @@ impl Event {
         check_assert!(allowed_flags.contains(flags))?;
         Ok(EventView::Out {
             side,
-            release_funds: flags.contains(EventFlag::ReleaseFunds),
+            release_funds: flags.contains(EventFlag::ReleaseFunds)
+                && flags.contains(EventFlag::SelfTradeCancel),
             native_qty_unlocked: self.native_qty_released,
             native_qty_still_locked: self.native_qty_paid,
 


### PR DESCRIPTION
Set release_funds to false if cancelled because of a self trade (Out event).

Note: we can alternatively make a new flag in the `EventFlag` enum in state.rs, but I thought this was better in practice.